### PR TITLE
Fix issue #12: ZIP圧縮機能追加

### DIFF
--- a/s3_upload.py
+++ b/s3_upload.py
@@ -9,15 +9,43 @@ def upload_csv(s3, df, bucket, key):
     df.to_csv(csv_buffer, index=False)
     s3.put_object(Bucket=bucket, Key=key, Body=csv_buffer.getvalue())
 
+def zip_csv_files(file_list, zip_path):
+    import zipfile
+    with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
+        for f in file_list:
+            zipf.write(f, arcname=os.path.basename(f))
+
+
 if __name__ == "__main__":
     if len(sys.argv) < 5:
         print("Usage: python s3_upload.py <input_file> <dst_bucket> <dst_key> <date>")
         sys.exit(1)
-    input_file = sys.argv[1]
+    input_path = sys.argv[1]
     dst_bucket = sys.argv[2]
     dst_key = sys.argv[3]
     date = sys.argv[4]
     s3 = boto3.client('s3')
-    df = pd.read_csv(input_file)
-    upload_csv(s3, df, dst_bucket, dst_key)
-    print(f"Uploaded {input_file} to s3://{dst_bucket}/{dst_key}")
+
+    # ZIP圧縮処理
+    import glob, tempfile
+    if os.path.isdir(input_path):
+        csv_files = sorted(glob.glob(os.path.join(input_path, '*.csv')))
+        if not csv_files:
+            print(f"No CSV files found in {input_path}")
+            sys.exit(1)
+        zip_files = []
+        for i in range(0, len(csv_files), 10):
+            zip_path = os.path.join(tempfile.gettempdir(), f'batch_{i//10+1}.zip')
+            zip_csv_files(csv_files[i:i+10], zip_path)
+            zip_files.append(zip_path)
+        for idx, zipf in enumerate(zip_files):
+            key = dst_key.replace('.csv', f'_batch{idx+1}.zip') if dst_key.endswith('.csv') else f'{dst_key}_batch{idx+1}.zip'
+            with open(zipf, 'rb') as f:
+                s3.put_object(Bucket=dst_bucket, Key=key, Body=f.read())
+            print(f"Uploaded {zipf} to s3://{dst_bucket}/{key}")
+    else:
+        # 単一CSVファイルの場合は従来通り
+        df = pd.read_csv(input_path)
+        upload_csv(s3, df, dst_bucket, dst_key)
+        print(f"Uploaded {input_path} to s3://{dst_bucket}/{dst_key}")
+

--- a/test_s3_upload.py
+++ b/test_s3_upload.py
@@ -13,3 +13,27 @@ def test_upload_csv(monkeypatch):
     assert ('bucket', 'key.csv') in s3.uploaded
     body = s3.uploaded[('bucket', 'key.csv')]
     assert 'a,b' in body and '1,3' in body
+
+def test_zip_csv_files(tmp_path):
+    import os
+    import zipfile
+    # Create 11 dummy CSV files
+    files = []
+    for i in range(11):
+        f = tmp_path / f"file_{i}.csv"
+        f.write_text(f"col1,col2\n{i},val{i}")
+        files.append(str(f))
+    zip1 = tmp_path / "batch1.zip"
+    zip2 = tmp_path / "batch2.zip"
+    # First 10 files
+    s3_upload.zip_csv_files(files[:10], str(zip1))
+    # Last 1 file
+    s3_upload.zip_csv_files(files[10:], str(zip2))
+    # Check contents
+    with zipfile.ZipFile(zip1) as z1:
+        assert len(z1.namelist()) == 10
+        for i in range(10):
+            assert f"file_{i}.csv" in z1.namelist()
+    with zipfile.ZipFile(zip2) as z2:
+        assert z2.namelist() == ["file_10.csv"]
+


### PR DESCRIPTION
This pull request fixes #12.

The changes implement the requested feature: before uploading to S3, CSV files are now grouped into batches of 10 and compressed into ZIP files. The main script checks if the input path is a directory, collects all CSV files, and for every 10 files, creates a ZIP archive. Each ZIP is then uploaded to S3 with a batch-specific key. If the input is a single CSV file, the original upload logic is used. Additionally, a test was added to verify that the ZIP function correctly batches and compresses files as intended. These changes directly address the requirement to ZIP every 10 CSV files before S3 upload, so the issue is resolved.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌